### PR TITLE
Handle prefixes & sheets without a number

### DIFF
--- a/lib/stream/xlsx/hyperlink-reader.js
+++ b/lib/stream/xlsx/hyperlink-reader.js
@@ -1,5 +1,6 @@
 const {EventEmitter} = require('events');
 const parseSax = require('../../utils/parse-sax');
+const parseSaxValue = require('../../utils/parse-sax-value');
 
 const Enums = require('../../doc/enums');
 const RelType = require('../../xlsx/rel-type');
@@ -44,7 +45,8 @@ class HyperlinkReader extends EventEmitter {
 
     try {
       for await (const events of parseSax(iterator)) {
-        for (const {eventType, value} of events) {
+        for (const {eventType, value: saxValue} of events) {
+          const value = parseSaxValue(saxValue);
           if (eventType === 'opentag') {
             const node = value;
             if (node.name === 'Relationship') {

--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -103,9 +103,9 @@ class WorkbookReader extends EventEmitter {
           await this._parseStyles(entry);
           break;
         default:
-          if (entry.path.match(/xl\/worksheets\/sheet\d+[.]xml/)) {
-            match = entry.path.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
-            sheetNo = match[1];
+          if (entry.path.match(/xl\/worksheets\/sheet\d*[.]xml/)) {
+            match = entry.path.match(/xl\/worksheets\/sheet(\d*)[.]xml/);
+            sheetNo = match[1] || 1;
             if (this.sharedStrings) {
               yield* this._parseWorksheet(iterateStream(entry), sheetNo);
             } else {
@@ -125,9 +125,9 @@ class WorkbookReader extends EventEmitter {
                 });
               });
             }
-          } else if (entry.path.match(/xl\/worksheets\/_rels\/sheet\d+[.]xml.rels/)) {
-            match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
-            sheetNo = match[1];
+          } else if (entry.path.match(/xl\/worksheets\/_rels\/sheet\d*[.]xml.rels/)) {
+            match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d*)[.]xml.rels/);
+            sheetNo = match[1] || 1;
             yield* this._parseHyperlinks(iterateStream(entry), sheetNo);
           }
           break;

--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -6,6 +6,7 @@ const unzip = require('unzipper');
 const tmp = require('tmp');
 const iterateStream = require('../../utils/iterate-stream');
 const parseSax = require('../../utils/parse-sax');
+const parseSaxValue = require('../../utils/parse-sax-value');
 
 const StyleManager = require('../../xlsx/xform/style/styles-xform');
 const WorkbookPropertiesManager = require('../../xlsx/xform/book/workbook-properties-xform');
@@ -174,7 +175,8 @@ class WorkbookReader extends EventEmitter {
     let text = null;
     let index = 0;
     for await (const events of parseSax(iterateStream(entry))) {
-      for (const {eventType, value} of events) {
+      for (const {eventType, value: saxValue} of events) {
+        const value = parseSaxValue(saxValue);
         if (eventType === 'opentag') {
           const node = value;
           if (node.name === 't') {

--- a/lib/stream/xlsx/worksheet-reader.js
+++ b/lib/stream/xlsx/worksheet-reader.js
@@ -1,5 +1,6 @@
 const {EventEmitter} = require('events');
 const parseSax = require('../../utils/parse-sax');
+const parseSaxValue = require('../../utils/parse-sax-value');
 
 const _ = require('../../utils/under-dash');
 const utils = require('../../utils/utils');
@@ -155,7 +156,8 @@ class WorksheetReader extends EventEmitter {
     let current = null;
     for await (const events of parseSax(iterator)) {
       const worksheetEvents = [];
-      for (const {eventType, value} of events) {
+      for (const {eventType, value: saxValue} of events) {
+        const value = parseSaxValue(saxValue);
         if (eventType === 'opentag') {
           const node = value;
           if (emitSheet) {

--- a/lib/utils/parse-sax-value.js
+++ b/lib/utils/parse-sax-value.js
@@ -1,0 +1,7 @@
+module.exports = function(value) {
+  if (value.name) {
+    // Remove prefixes
+    value.name = value.name.replace(/^\w+:/, '');
+  }
+  return value;
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Two issues attempted to be fixed here:

**Incorrect sheet reference**
Typically a workbook XML should contain references to all the sheets inside a workbook. The package used for the fileprocessor expects that these sheets all have a number, but in this file the sheet ID is just sheet, which seems incorrect. Opening in Excel and resaving corrects the XML.

**Use of a namespace**
On top of this, the XML seems to provide a namespace which get prefixed to all the nodes. Again opening in Excel and resaving corrects the XML, but for the package this results in there appearing to be no data. 

**Screenshot of the issues**
![image](https://user-images.githubusercontent.com/26712915/89129444-549ef100-d4f5-11ea-9b80-1f6339bcace2.png)

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
